### PR TITLE
修正節點繼承問題

### DIFF
--- a/1.6/CE/Patches/ModuleWeapon_CE.xml
+++ b/1.6/CE/Patches/ModuleWeapon_CE.xml
@@ -49,7 +49,7 @@
             <li Class="PatchOperationReplace">
                 <xpath>Defs/ThingDef[defName="DMS_Dragoon_Axe"]/tools</xpath>
                 <value>
-                    <tools>
+                    <tools Inherit="False">
                         <li Class="CombatExtended.ToolCE">
                             <label>stock</label>
                             <capacities>
@@ -88,7 +88,7 @@
             <li Class="PatchOperationReplace">
                 <xpath>Defs/ThingDef[defName="DMS_Dragoon_Sword"]/tools</xpath>
                 <value>
-                    <tools>
+                    <tools Inherit="False">
                         <li Class="CombatExtended.ToolCE">
                             <label>stock</label>
                             <capacities>


### PR DESCRIPTION
龍7近戰武器的tool繼承到父系節點了 上了不繼承的xml